### PR TITLE
Initial Docker Support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,39 @@
+# Python 3.10 w/ Nvidia Cuda
+FROM nvidia/cuda:11.8.0-devel-ubuntu22.04 AS env_base
+
+# Install Pre-reqs
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    git vim nano build-essential python3-dev python3-venv python3-pip gcc g++ ffmpeg
+
+# Setup venv
+RUN pip3 install virtualenv
+RUN virtualenv /venv
+ENV VIRTUAL_ENV=/venv
+RUN python3 -m venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+RUN pip3 install --upgrade pip setuptools && \
+    pip3 install torch torchvision torchaudio
+
+# Set working directory
+WORKDIR /app
+
+# Clone the repo
+RUN git clone https://github.com/rsxdalv/tts-generation-webui.git
+
+# Set working directory to the cloned repo
+WORKDIR /app/tts-generation-webui
+
+# Install all requirements
+RUN pip3 install -r requirements.txt
+RUN pip3 install -r requirements_audiocraft.txt
+RUN pip3 install -r requirements_bark_hubert_quantizer.txt
+RUN pip3 install -r requirements_rvc.txt
+
+# Install requirements for models
+WORKDIR /app/tts-generation-webui/models
+
+# Set working directory back to the root of the repo
+WORKDIR /app/tts-generation-webui
+
+# Run the server
+CMD python server.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,11 +29,5 @@ RUN pip3 install -r requirements_audiocraft.txt
 RUN pip3 install -r requirements_bark_hubert_quantizer.txt
 RUN pip3 install -r requirements_rvc.txt
 
-# Install requirements for models
-WORKDIR /app/tts-generation-webui/models
-
-# Set working directory back to the root of the repo
-WORKDIR /app/tts-generation-webui
-
 # Run the server
 CMD python server.py

--- a/README.md
+++ b/README.md
@@ -156,6 +156,26 @@ Not exactly, the dependencies clash, especially between conda and python (and de
 
 * Potentially needed to install build tools (without Visual Studio): https://visualstudio.microsoft.com/visual-cpp-build-tools/
 
+## Docker Setup
+
+tts-generation-webui can also be ran inside of a Docker container. To get started, first build the Docker container while in the root directory:
+
+```
+docker build -t rsxdalv/tts-generation-webui .
+```
+
+Once the container has built it can be started with Docker Compose:
+
+```
+docker compose up -d
+```
+
+The container will take some time to generate the first output while models are downloaded in the background. The status of this download can be verified by checking the container logs:
+
+```
+docker logs tts-generation-webui
+```
+
 ## Open Source Libraries
 
 This project utilizes the following open source libraries:

--- a/README.md
+++ b/README.md
@@ -158,13 +158,13 @@ Not exactly, the dependencies clash, especially between conda and python (and de
 
 ## Docker Setup
 
-tts-generation-webui can also be ran inside of a Docker container. To get started, first build the Docker container while in the root directory:
+tts-generation-webui can also be ran inside of a Docker container. To get started, first build the Docker image while in the root directory:
 
 ```
 docker build -t rsxdalv/tts-generation-webui .
 ```
 
-Once the container has built it can be started with Docker Compose:
+Once the image has built it can be started with Docker Compose:
 
 ```
 docker compose up -d

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3'
+services:
+  tts-generation-webui:
+    image: rsxdalv/tts-generation-webui
+    restart: unless-stopped
+    ports:
+      - "7860:7860"
+    container_name: tts-generation-webui
+    deploy:
+        resources:
+          reservations:
+            devices:
+              - driver: nvidia
+                device_ids: ['0']
+                capabilities: [gpu]


### PR DESCRIPTION
I have been deploying text-gen-ui & Stable Diffusion via Docker and noticed tts-gen-ui did not have a Docker option, so added a Dockerfile to support it. Details on how to build and deploy via Docker are included in the Readme.

Currently it is setup so that users are required to pull the repo, build the image and then deploy it. There could be an opportunity to host pre-built images at `rsxdalv/tts-generation-webui` to help users bypass this step.

Have been testing it for the past few days without issue but let me know if any questions or updates required.

Thanks!



