### PR TITLE
RVC UI naming improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,15 @@ Google Colab demo: [![Open In Colab](https://colab.research.google.com/assets/co
 
 [audio__bark__continued_generation__2023-05-04_16-10-55_long.webm](https://user-images.githubusercontent.com/6757283/236219243-dad96404-0879-4274-828e-7f3afc6bac65.webm)
 
-## Extra Voices
+## Extra Voices for Bark
+https://echo.play.ai/
 https://rsxdalv.github.io/bark-speaker-directory/
 
 ## Changelog
+July 23:
+* Docker Image thanks to https://github.com/jonfairbanks
+* RVC UI naming improvements
+
 July 21:
 * Fix hubert not working with CPU only (https://github.com/rsxdalv/tts-generation-webui/pull/87)
 * Add Google Colab demo (https://github.com/rsxdalv/tts-generation-webui/pull/88)

--- a/src/rvc_tab/rvc_tab.py
+++ b/src/rvc_tab/rvc_tab.py
@@ -166,7 +166,8 @@ def rvc_ui_model_or_index_path_ui(label: str):
                 value=os.path.join(RVC_LOCAL_MODELS_DIR, f"{model}{extension}")
             ),
             file_path_file.update(value=None),
-        ] if model is not None
+        ]
+        if model is not None
         else [
             file_path.update(),
             file_path_file.update(),
@@ -187,34 +188,40 @@ def rvc_ui():
                 with gr.Column():
                     index_path = rvc_ui_model_or_index_path_ui("Index")
             with gr.Row():
-                f0up_key = gr.Textbox(label="f0 Up key", value="0")
+                f0up_key = gr.Textbox(label="Pitch Up key", value="0")
                 # f0method = gr.Dropdown(
                 #     ["harvest", "pm", "crepe"], label="f0 Method", value="harvest"
                 # )
                 f0method = gr.Radio(
-                    ["harvest", "pm", "crepe"], label="f0 Method", value="harvest"
+                    ["harvest", "pm", "crepe"],
+                    label="Pitch Collection Method",
+                    value="harvest",
                 )
                 index_rate = gr.Slider(
-                    minimum=0.0, maximum=1.0, step=0.01, value=0.66, label="Index Rate"
+                    minimum=0.0, maximum=1.0, step=0.01, value=0.66, label="Search Feature Ratio"
                 )
                 filter_radius = gr.Slider(
-                    minimum=0, maximum=10, step=1, value=3, label="Filter Radius"
+                    minimum=0, maximum=10, step=1, value=3, label="Filter Radius (Pitch)"
                 )
             with gr.Row():
                 resample_sr = gr.Slider(
-                    minimum=0, maximum=48000, step=1, value=0, label="Resample SR"
+                    minimum=0,
+                    maximum=48000,
+                    step=1,
+                    value=0,
+                    label="Resample Sample-rate (Bug)",
                 )
                 rms_mix_rate = gr.Slider(
-                    minimum=0.0, maximum=1.0, step=0.01, value=1, label="RMS Mix Rate"
+                    minimum=0.0, maximum=1.0, step=0.01, value=1, label="Voice Envelope Normalizaiton"
                 )
                 protect = gr.Slider(
-                    minimum=0.0, maximum=1.0, step=0.01, value=0.33, label="Protect"
+                    minimum=0.0, maximum=0.5, step=0.01, value=0.33, label="Protect Breath Sounds"
                 )
             with gr.Group():
                 gr.Markdown("### Hubert")
                 with gr.Row():
                     device = gr.Dropdown(
-                        ["cuda:0", "cpu"], label="Device", value="cuda:0"
+                        ["cuda:0", "cpu", "mps"], label="Device", value="cuda:0"
                     )
                     is_half = gr.Checkbox(
                         label="Use half precision model (Depends on GPU support)",
@@ -224,8 +231,8 @@ def rvc_ui():
                         value="Clear Hubert (to reload on next generation)",
                         variant="secondary",
                     ).click(
-                        fn=lambda: inject_hubert(None)
-                    )  # type: ignore
+                        fn=lambda: inject_hubert(None)  # type: ignore
+                    )
 
         with gr.Column():
             original_audio = Joutai.singleton.rvc_input


### PR DESCRIPTION
1. Renamed "f0 Up key" to "Pitch Up key."
2. Renamed "f0 Method" to "Pitch Collection Method."
3. Renamed "Index Rate" to "Search Feature Ratio."
4. Renamed "Filter Radius" to "Filter Radius (Pitch)."
5. Renamed "Resample SR" to "Resample Sample-rate (Bug)."
6. Renamed "RMS Mix Rate" to "Voice Envelope Normalization."
7. Changed "protect" slider range to 0.0-0.5 and updated the label to "Protect Breath Sounds."
8. Added "mps" option to "Device" dropdown, along with "cuda:0" and "cpu" options.
