### PR TITLE
Update Bark license notice in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -688,7 +688,7 @@ Known non-permissive dependencies:
 Model weights have different licenses, please pay attention to the license of the model you are using.
 
 Most notably:
-- Bark: *CC BY-NC 4.0* (MIT but HuggingFace has not been updated yet)
+- Bark: MIT
 - Tortoise: *Unknown* (Apache-2.0 according to repo, but no license file in HuggingFace)
 - MusicGen: CC BY-NC 4.0
 - AudioGen: CC BY-NC 4.0


### PR DESCRIPTION
The license for Bark has been changed to MIT in both [the GitHub repository](https://github.com/suno-ai/bark) and [the HuggingFace repository](https://huggingface.co/suno/bark), so this repository's README can be updated accordingly.