### PR TITLE
feat: rename all extension_ packages to tts_webui_extension.*

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ September:
 * Add PyRNNoise extension
 * Upgrade React UI's Chatterbox interface
 * Rename Kokoro TTS extension to OpenAI TTS API extension
+* Rename all extensions to tts_webui_extension.*
 
 August:
 * Fix model downloader when no token is used, thanks Nusantara.

--- a/extensions.json
+++ b/extensions.json
@@ -462,7 +462,7 @@
         },
         {
             "package_name": "tts_webui_extension.gpt_sovits",
-            "name": "GPT-SoVITS",
+            "name": "GPT-SoVITS [low compatibility]",
             "requirements": "git+https://github.com/rsxdalv/tts_webui_extension.gpt_sovits@main",
             "description": "GPT-SoVITS: A TTS solution powered by GPT and SoftVC VITS Singing Voice Conversion.",
             "extension_type": "interface",


### PR DESCRIPTION
This is part of migration process to normalize these packages in the 'global' pip ecosystem rather than using arbitrary names that might clash with others.