### PR TITLE
chore: migrate FireRedTTS2, VoxCPM, MegaTTS3 extensions to uv

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,17 @@
 
 ## Installation
 
-### Using the Installer (Recommended)
+### Using TTS WebUI Ignition (Recommended)
+TTS WebUI Ignition is the new installer and launcher for TTS WebUI.
+
+On Windows:
+```
+winget install TTS-WebUI.Ignition
+```
+
+For other platforms, download the latest release from the [releases page](https://github.com/rsxdalv/tts-webui-ignition/releases/tag/release-v2.2.0) or build it from source using the instructions in the [repository](https://github.com/rsxdalv/tts-webui-ignition).
+
+### Using the Installer (Legacy)
 
 Current base installation size is around 10.7 GB. Each model will require 2-8 GB of space in addition.
 

--- a/extensions.json
+++ b/extensions.json
@@ -468,7 +468,7 @@
             },
             {
                 "package_name": "tts_webui_extension.vox_cpm",
-                "name": "VoxCPM (Beta)",
+                "name": "VoxCPM (uv)",
                 "requirements": "git+https://github.com/rsxdalv/tts_webui_extension.vox_cpm@main",
                 "description": "A template extension for TTS Generation WebUI",
                 "extension_type": "interface",
@@ -478,7 +478,8 @@
                 "license": "MIT",
                 "website": "https://github.com/rsxdalv/tts_webui_extension.vox_cpm",
                 "extension_website": "https://github.com/rsxdalv/tts_webui_extension.vox_cpm",
-                "extension_platform_version": "0.0.1"
+                "extension_platform_version": "0.0.1",
+                "proxy": "native"
             },
             {
                 "package_name": "tts_webui_extension.fireredtts2",

--- a/extensions.json
+++ b/extensions.json
@@ -498,7 +498,7 @@
             },
             {
                 "package_name": "tts_webui_extension.megatts3",
-                "name": "MegaTTS3 (Alpha)",
+                "name": "MegaTTS3 (uv)",
                 "requirements": "git+https://github.com/rsxdalv/tts_webui_extension.megatts3@main",
                 "description": "A template extension for TTS Generation WebUI",
                 "extension_type": "interface",
@@ -508,7 +508,8 @@
                 "license": "MIT",
                 "website": "https://github.com/rsxdalv/tts_webui_extension.megatts3",
                 "extension_website": "https://github.com/rsxdalv/tts_webui_extension.megatts3",
-                "extension_platform_version": "0.0.1"
+                "extension_platform_version": "0.0.1",
+                "proxy": "native"
             }
         ],
         "audio-music-generation": [

--- a/extensions.json
+++ b/extensions.json
@@ -482,7 +482,7 @@
             },
             {
                 "package_name": "tts_webui_extension.fireredtts2",
-                "name": "FireRedTTS2 (Beta)",
+                "name": "FireRedTTS2 (uv)",
                 "requirements": "git+https://github.com/rsxdalv/tts_webui_extension.fireredtts2@main",
                 "description": "A template extension for TTS Generation WebUI",
                 "extension_type": "interface",
@@ -492,7 +492,8 @@
                 "license": "MIT",
                 "website": "https://github.com/rsxdalv/tts_webui_extension.fireredtts2",
                 "extension_website": "https://github.com/rsxdalv/tts_webui_extension.fireredtts2",
-                "extension_platform_version": "0.0.1"
+                "extension_platform_version": "0.0.1",
+                "proxy": "native"
             },
             {
                 "package_name": "tts_webui_extension.megatts3",


### PR DESCRIPTION
Note: VoxCPM still needs upgrade to latest, MegaTTS3 requires pynini - Windows wheels need to be tied into the package.